### PR TITLE
:white_check_mark: Added sample tests for redux and redux provider wrapper

### DIFF
--- a/template/__tests__/slices/sampleSlice.test.tsx
+++ b/template/__tests__/slices/sampleSlice.test.tsx
@@ -1,0 +1,38 @@
+// Store
+import reducer, {
+    setObjectData,
+    updateObjectValue,
+    initialState,
+    resetReducer,
+} from 'slices/sampleSlice';
+
+describe('Sample Slice Testing', () => {
+    it('updateObjectValue should update the state object appropriately given an updated value', () => {
+        expect(
+            reducer(initialState, updateObjectValue({ value: 'testValue' })),
+        ).toEqual({
+            ...initialState,
+            object: {
+                ...initialState.object,
+                value: 'testValue',
+            },
+        });
+    });
+
+    it('setObjectData should set the state object appropriately', () => {
+        const updatedObject = {
+            id: '1234',
+            value: 'testValue',
+            anotherValue: 'foo',
+        };
+
+        expect(reducer(initialState, setObjectData(updatedObject))).toEqual({
+            ...initialState,
+            object: updatedObject,
+        });
+    });
+
+    it('reset reducer should reset the reducer to its initial state', () => {
+        expect(reducer(initialState, resetReducer())).toEqual(initialState);
+    });
+});

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -8,4 +8,33 @@ module.exports = {
     transformIgnorePatterns: [
         '/node_modules/(?!(@react-native|react-native|rn-progressive-image|react-native-reanimated|@react-native-community)/).*/',
     ],
+    collectCoverageFrom: [
+        './src/components/**/index.{js,jsx,ts,tsx}',
+        '!./src/components/index.{js,jsx,ts,tsx}',
+        './src/screens/*/*/index.{js,jsx,ts,tsx}',
+        './src/slices/**.{js,jsx,ts,tsx}',
+        '!./src/slices/index.{js,jsx,ts,tsx}',
+        '!**/*.d.ts',
+        '!**/node_modules/**',
+        '!./coverage/**',
+        '!./index.js',
+        '!./jest.config.js',
+        '!./metro.config.js',
+        '!./babel.config.js',
+        '!./react-native.config.js',
+        '!./.eslintrc.js',
+        '!./.prettierrc.js',
+        '!./src/assets/**',
+        '!./src/types/**',
+        '!./src/constants/**',
+    ],
+    // The below lines are for calculating your coverage threshold. Set the coverage threshold to your desired target coverage and then uncomment.
+    // coverageThreshold: {
+    //     global: {
+    //         branches: 90,
+    //         functions: 90,
+    //         lines: 90,
+    //         statements: 90,
+    //     },
+    // },
 };

--- a/template/package.json
+++ b/template/package.json
@@ -7,6 +7,8 @@
         "ios": "react-native run-ios",
         "start": "react-native start",
         "test": "jest",
+        "test:coverage": "jest --coverage --watchAll=false",
+        "test:update": "jest --coverage --watchAll=false --updateSnapshot",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
     },
     "dependencies": {

--- a/template/src/utils/index.tsx
+++ b/template/src/utils/index.tsx
@@ -1,1 +1,2 @@
 export { default as dimensions } from './dimensions';
+export { default as render } from './providers';

--- a/template/src/utils/providers.tsx
+++ b/template/src/utils/providers.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+// Packages
+import { Provider } from 'react-redux';
+import { render, RenderOptions } from '@testing-library/react-native';
+
+// Store
+import store from 'store/configureStore';
+
+const AllProviders = ({ children }: { children?: ReactNode }) => {
+    return <Provider store={store}>{children}</Provider>;
+};
+
+const customRender = (ui: ReactElement, options?: RenderOptions) =>
+    render(ui, { wrapper: AllProviders, ...options });
+
+export default customRender;


### PR DESCRIPTION
For the sake of keeping things consistent, example tests for the sampleSlice of RTK has been added. Additionally, a custom render wrapper has been created that allows us to wrap our render functionality within a Redux Store.